### PR TITLE
Move requires of out loops

### DIFF
--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -31,20 +31,24 @@ exports.createPages = async ({ graphql, actions }) => {
   const articles = result.data.articles.edges
   const categories = result.data.categories.edges
 
+  const ArticleTemplate = require.resolve("./src/templates/article.js")
+
   articles.forEach((article, index) => {
     createPage({
       path: `/article/${article.node.slug}`,
-      component: require.resolve("./src/templates/article.js"),
+      component: ArticleTemplate,
       context: {
         slug: article.node.slug,
       },
     })
   })
 
+  const CategoryTemplate = require.resolve("./src/templates/category.js")
+
   categories.forEach((category, index) => {
     createPage({
       path: `/category/${category.node.slug}`,
-      component: require.resolve("./src/templates/category.js"),
+      component: CategoryTemplate,
       context: {
         slug: category.node.slug,
       },


### PR DESCRIPTION
Small PR to apply the [feedback I got from the Gatsby team](https://github.com/gatsbyjs/gatsby/pull/26245#discussion_r465875560) for the willitbuild integration

Moving the requires out of the loop is a bit better for performance